### PR TITLE
Handle multiple IDVARs in SUPP merge

### DIFF
--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -388,37 +388,58 @@ class DataProcessor:
     ):
 
         static_keys = ["STUDYID", "USUBJID", "APID", "POOLID", "SPDEVID"]
-        qnam_list = right_dataset["QNAM"].unique()
-        right_dataset = DataProcessor.process_supp(right_dataset)
-        dynamic_key = right_dataset["IDVAR"].iloc[0]
+        idvars = right_dataset["IDVAR"].unique()
 
-        # Determine the common keys present in both datasets
-        common_keys = [
-            key
-            for key in static_keys
-            if key in left_dataset.columns and key in right_dataset.columns
-        ]
-        common_keys.append(dynamic_key)
-        current_supp = right_dataset.rename(columns={"IDVARVAL": dynamic_key})
-        current_supp = current_supp.drop(columns=["IDVAR"])
-        left_dataset[dynamic_key] = left_dataset[dynamic_key].astype(str)
-        current_supp[dynamic_key] = current_supp[dynamic_key].astype(str)
-        left_dataset = PandasDataset(
-            pd.merge(
-                left_dataset.data,
-                current_supp.data,
-                how="left",
-                on=common_keys,
-                suffixes=("", "_supp"),
+        for dynamic_key in idvars:
+            current_supp = right_dataset.__class__(
+                right_dataset.data[right_dataset["IDVAR"] == dynamic_key]
             )
-        )
-        for qnam in qnam_list:
-            qnam_check = left_dataset.data.dropna(subset=[qnam])
-            grouped = qnam_check.groupby(common_keys).size()
-            if (grouped > 1).any():
-                raise ValueError(
-                    f"Multiple records with the same QNAM '{qnam}' match a single parent record"
+            qnam_list = current_supp["QNAM"].unique()
+            current_supp = DataProcessor.process_supp(current_supp)
+
+            common_keys = [
+                key
+                for key in static_keys
+                if key in left_dataset.columns and key in current_supp.columns
+            ]
+            common_keys.append(dynamic_key)
+
+            current_supp = current_supp.rename(columns={"IDVARVAL": dynamic_key})
+            current_supp = current_supp.drop(columns=["IDVAR"])
+
+            if dynamic_key in left_dataset.columns:
+                left_dataset[dynamic_key] = left_dataset[dynamic_key].astype(str)
+            current_supp[dynamic_key] = current_supp[dynamic_key].astype(str)
+
+            left_dataset = PandasDataset(
+                pd.merge(
+                    left_dataset.data,
+                    current_supp.data,
+                    how="left",
+                    on=common_keys,
+                    suffixes=("", "_supp"),
                 )
+            )
+
+            for qnam in qnam_list:
+                supp_column = f"{qnam}_supp"
+                if supp_column in left_dataset.columns:
+                    if qnam in left_dataset.columns:
+                        left_dataset[qnam] = left_dataset[qnam].combine_first(
+                            left_dataset[supp_column]
+                        )
+                        left_dataset = left_dataset.drop(columns=[supp_column])
+                    else:
+                        left_dataset = left_dataset.rename(
+                            columns={supp_column: qnam}
+                        )
+
+                qnam_check = left_dataset.data.dropna(subset=[qnam])
+                grouped = qnam_check.groupby(common_keys).size()
+                if (grouped > 1).any():
+                    raise ValueError(
+                        f"Multiple records with the same QNAM '{qnam}' match a single parent record"
+                    )
         if dataset_implementation == DaskDataset:
             left_dataset = DaskDataset(left_dataset.data)
         return left_dataset

--- a/tests/unit/test_merge_supp_datasets.py
+++ b/tests/unit/test_merge_supp_datasets.py
@@ -123,3 +123,65 @@ def test_merge_pivot_supp_dataset(
     )
     assert len(merged_dataset.data) == len(parent_dataset.data), "The"
     " length of the merged dataset should match the parent dataset."
+
+
+@patch.object(LocalDataService, "check_filepath", return_value=False)
+@patch.object(LocalDataService, "_async_get_datasets")
+def test_merge_pivot_supp_dataset_multiple_idvar(
+    mock_async_get_datasets, mock_check_filepath, data_service
+):
+    parent_dataset = PandasDataset(
+        pd.DataFrame(
+            {
+                "STUDYID": [1, 2, 3, 4],
+                "USUBJID": [101, 102, 103, 104],
+                "APID": [201, 202, 203, 204],
+                "POOLID": [301, 302, 303, 304],
+                "SPDEVID": [401, 402, 403, 404],
+                "A": ["1", "2", "3", "4"],
+                "B": ["10", "20", "30", "40"],
+            }
+        )
+    )
+
+    supp_dataset = PandasDataset(
+        pd.DataFrame(
+            {
+                "STUDYID": [1, 2, 3, 4],
+                "USUBJID": [101, 102, 103, 104],
+                "APID": [201, 202, 203, 204],
+                "POOLID": [301, 302, 303, 304],
+                "SPDEVID": [401, 402, 403, 404],
+                "IDVAR": ["A", "A", "B", "B"],
+                "IDVARVAL": ["1", "2", "30", "40"],
+                "QNAM": ["X", "X", "Y", "Y"],
+                "QVAL": [100, 200, 300, 400],
+                "QLABEL": ["L1", "L2", "L3", "L4"],
+            }
+        )
+    )
+
+    merged_dataset = DataProcessor.merge_pivot_supp_dataset(
+        data_service.dataset_implementation, parent_dataset, supp_dataset
+    )
+
+    expected_dataset = PandasDataset(
+        pd.DataFrame(
+            {
+                "STUDYID": [1, 2, 3, 4],
+                "USUBJID": [101, 102, 103, 104],
+                "APID": [201, 202, 203, 204],
+                "POOLID": [301, 302, 303, 304],
+                "SPDEVID": [401, 402, 403, 404],
+                "A": ["1", "2", "3", "4"],
+                "B": ["10", "20", "30", "40"],
+                "X": [100, 200, pd.NA, pd.NA],
+                "Y": [pd.NA, pd.NA, 300, 400],
+            }
+        )
+    )
+
+    pdt.assert_frame_equal(
+        merged_dataset.data, expected_dataset.data, check_dtype=False
+    )
+    assert len(merged_dataset.data) == len(parent_dataset.data)


### PR DESCRIPTION
## Summary
- allow merge_pivot_supp_dataset to handle multiple IDVAR values
- test SUPP merge with multiple IDVARs

## Testing
- `flake8 cdisc_rules_engine/utilities/data_processor.py tests/unit/test_merge_supp_datasets.py`
- `PYTHONPATH=. pytest tests/unit/test_merge_supp_datasets.py::test_merge_pivot_supp_dataset tests/unit/test_merge_supp_datasets.py::test_merge_pivot_supp_dataset_multiple_idvar -q`